### PR TITLE
fix check if SMTP accepts auth extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- nothing changed
+- always try to login to SMTP server without checking if server accepts authentication. If an error is raised just pass and do not block connection.
 
 ### Removed
 

--- a/concrete_mailer/utils.py
+++ b/concrete_mailer/utils.py
@@ -1,14 +1,17 @@
 # coding: utf-8
-from smtplib import SMTP
+from smtplib import SMTP, SMTPNotSupportedError
 
 
 def get_connection(host, port, user, password, use_tls=True):
     connection = SMTP(host=host, port=port)
     if use_tls:
         connection.starttls()
-    # Ensure the SMTP server support the auth extension?
-    if connection.has_extn('auth'):
+    #:  Some SMTP servers does not support authentication.
+    #:  If login raises SMTPNotSupportedError do not block the connection.
+    try:
         connection.login(user, password)
+    except SMTPNotSupportedError:
+        pass
     return connection
 
 


### PR DESCRIPTION
Do not check if the SMTP server accepts authentication before login. Wrap login method with a try/except instead