### PR TITLE
Update jinja version to fix markupsafe error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ zip_safe = false
 install_requires =
     premailer>=3.6.1,<4
     beautifulsoup4>=4.8.0,<5
-    jinja2>=2.10.1,<3
+    jinja2>=3.0.3,<4
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Changing jinja2 version will fix this error:
https://github.com/pallets/jinja/issues/1585

And the version 2.X of jinja2 is no longer maintained